### PR TITLE
optimize encoder

### DIFF
--- a/internal/priorityqueue/priorityqueue.go
+++ b/internal/priorityqueue/priorityqueue.go
@@ -17,10 +17,10 @@ type PriorityQueue[T any] struct {
 
 // New creates a new PriorityQueue, configured with a function that
 // compares the priorities of two items a and b; it should return a number > 0
-// if the priority of a is higher, 0 if the priorities are equal a number < 0
-// otherwise.
-func New[T any](cmp func(a, b T) int) *PriorityQueue[T] {
-	return &PriorityQueue[T]{cmp: cmp, items: make([]T, 1)}
+// if the priority of a is higher, 0 if the priorities are equal, and a number < 0 otherwise.
+// sizeHint sets the initial capacity of the queue; -1 means to use the default.
+func New[T any](sizeHint int, cmp func(a, b T) int) *PriorityQueue[T] {
+	return &PriorityQueue[T]{cmp: cmp, items: make([]T, 1, max(1, sizeHint+1))}
 }
 
 // Len returns the length (number of items) of the priority queue.

--- a/processor.go
+++ b/processor.go
@@ -210,7 +210,7 @@ func (proc *Processor) Encode(text string) []Token {
 		score       float32
 	}
 
-	mergeQueue := priorityqueue.New(func(a, b mergeCandidate) int {
+	mergeQueue := priorityqueue.New(len(symList), func(a, b mergeCandidate) int {
 		if a.score > b.score || (a.score == b.score && a.left < b.left) {
 			return 1
 		}
@@ -307,10 +307,12 @@ func (proc *Processor) symbolMatch(text string) (int, bool) {
 	return rlen, false
 }
 
-const symbolBOS = "<bos>"
-const symbolEOS = "<eos>"
-const symbolUNK = "<unk>"
-const symbolPAD = "<pad>"
+const (
+	symbolBOS = "<bos>"
+	symbolEOS = "<eos>"
+	symbolUNK = "<unk>"
+	symbolPAD = "<pad>"
+)
 
 // symbolToID finds the right ID for the given textual symbol, or returns
 // proc.unknownID if the symbol is unknown.

--- a/processor.go
+++ b/processor.go
@@ -188,6 +188,7 @@ func (proc *Processor) Encode(text string) []Token {
 		return nil
 	}
 	symList[len(symList)-1].next = -1
+	nTokens := len(symList)
 
 	debugShowSymList := func(prefix string) {
 		if debugEncode {
@@ -258,6 +259,7 @@ func (proc *Processor) Encode(text string) []Token {
 		// Do the merge:
 		// 1. Merge the concatenation of leftSymbol and rightSymbol into leftSymbol
 		symList[candidate.left].symbol = leftSymbol.symbol + rightSymbol.symbol
+		nTokens--
 
 		// 2. Update prev/next pointers
 		symList[candidate.left].next = rightSymbol.next
@@ -275,7 +277,7 @@ func (proc *Processor) Encode(text string) []Token {
 	}
 
 	// Collect the final list of tokens from the remaining elements of symList.
-	tokens := make([]Token, 0, len(symList))
+	tokens := make([]Token, 0, nTokens)
 	for i := 0; i >= 0; i = symList[i].next {
 		symbol := symList[i].symbol
 		id := proc.symbolToID(symbol)


### PR DESCRIPTION
This is a grab-bag of optimizations.
I recommend reviewing commit-by-commit and rebasing instead of squashing.

Their cumulative effect, on my laptop, for an out-of-tree benchmark (sorry) is:

```
goos: darwin
goarch: arm64
pkg: bold.dev/tknz/gemma2b
cpu: Apple M3 Max
          │      a      │                  f                  │
          │   sec/op    │   sec/op     vs base                │
PureGo-16   3.494m ± 6%   2.642m ± 1%  -24.39% (p=0.000 n=15)

          │       a       │                  f                   │
          │     B/op      │     B/op      vs base                │
PureGo-16   1858.5Ki ± 0%   824.0Ki ± 0%  -55.66% (p=0.000 n=15)

          │       a       │                 f                  │
          │   allocs/op   │ allocs/op   vs base                │
PureGo-16   7574.000 ± 0%   4.000 ± 0%  -99.95% (p=0.000 n=15)
```

I also will understand if these are viewed as too intrusive/complicated for this codebase. :) I am happy to maintain a fork as needed.